### PR TITLE
Feature/authproc

### DIFF
--- a/config-templates/module_casserver.php
+++ b/config-templates/module_casserver.php
@@ -55,8 +55,19 @@ $config = [
     ],
 
     'attrname' => 'eduPersonPrincipalName', // 'eduPersonPrincipalName',
-    'attributes' => true, // enable transfer of attributes, defaults to false
+    'attributes' => true, // enable transfer of attributes, defaults to true
     'attributes_to_transfer' => ['eduPersonPrincipalName'], // set of attributes to transfer, defaults to all
+
+    /* Optional authproc filter. Only authproc filters that solely rely on attributes (such as core:AttributeMap and AttributeAlter)
+       may be used. If your authsource supports authproc filters you are better off doing it there. */
+    'authproc' => array(
+        array(
+            'class' => 'core:AttributeMap',
+            'oid2name',
+            'urn:example' => 'example'
+        ),
+        // Additonal authproc filter
+    ),
 
     'base64attributes' => true, // base64 encode transferred attributes, defaults to false
     'base64_attributes_indicator_attribute' => 'base64Attributes', /*add an attribute with the value of the base64attributes

--- a/config-templates/module_casserver.php
+++ b/config-templates/module_casserver.php
@@ -60,14 +60,14 @@ $config = [
 
     /* Optional authproc filter. Only authproc filters that solely rely on attributes (such as core:AttributeMap and AttributeAlter)
        may be used. If your authsource supports authproc filters you are better off doing it there. */
-    'authproc' => array(
-        array(
+    'authproc' => [
+        [
             'class' => 'core:AttributeMap',
             'oid2name',
             'urn:example' => 'example'
-        ),
+        ],
         // Additonal authproc filter
-    ),
+    ],
 
     'base64attributes' => true, // base64 encode transferred attributes, defaults to false
     'base64_attributes_indicator_attribute' => 'base64Attributes', /*add an attribute with the value of the base64attributes

--- a/lib/Cas/AttributeExtractor.php
+++ b/lib/Cas/AttributeExtractor.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Extract the user and any mapped attributes from the AuthSource attributes
+ */
+class sspmod_casserver_Cas_AttributeExtractor
+{
+
+    /**
+     * Determine the user and any CAS attributes based on the attributes from the
+     * authsource and the CAS configuration.
+     *
+     * The result is an array
+     * [
+     *   'user' => 'user_value',
+     *   'attributes' => [
+     *    // any attributes
+     * ]
+     *
+     * If no CAS attributes are configured then the attributes array is empty
+     * @param array $attributes
+     * @param SimpleSAML_Configuration $casconfig
+     * @return array
+     */
+    public function extractUserAndAttributes(array $attributes, SimpleSAML_Configuration $casconfig)
+    {
+        $casUsernameAttribute = $casconfig->getValue('attrname', 'eduPersonPrincipalName');
+
+        //TODO: how should a missing userName be handled?
+        $userName = $attributes[$casUsernameAttribute][0];
+
+        if ($casconfig->getValue('attributes', true)) {
+            $attributesToTransfer = $casconfig->getValue('attributes_to_transfer', array());
+
+            if (sizeof($attributesToTransfer) > 0) {
+                $casAttributes = array();
+
+                foreach ($attributesToTransfer as $key) {
+                    if (array_key_exists($key, $attributes)) {
+                        $casAttributes[$key] = $attributes[$key];
+                    }
+                }
+            } else {
+                $casAttributes = $attributes;
+            }
+        } else {
+            $casAttributes = array();
+        }
+
+        return array(
+            'user' => $userName,
+            'attributes' => $casAttributes
+        );
+    }
+}

--- a/lib/Cas/AttributeExtractor.php
+++ b/lib/Cas/AttributeExtractor.php
@@ -1,5 +1,8 @@
 <?php
 
+use SimpleSAML\Configuration;
+use SimpleSAML\Module;
+
 /**
  * Extract the user and any mapped attributes from the AuthSource attributes
  */
@@ -19,10 +22,10 @@ class sspmod_casserver_Cas_AttributeExtractor
      *
      * If no CAS attributes are configured then the attributes array is empty
      * @param array $attributes
-     * @param SimpleSAML_Configuration $casconfig
+     * @param \SimpleSAML\Configuration $casconfig
      * @return array
      */
-    public function extractUserAndAttributes(array $attributes, SimpleSAML_Configuration $casconfig)
+    public function extractUserAndAttributes(array $attributes, Configuration $casconfig)
     {
         if ($casconfig->hasValue('authproc')) {
             $attributes = $this->invokeAuthProc($attributes, $casconfig);
@@ -34,10 +37,10 @@ class sspmod_casserver_Cas_AttributeExtractor
         $userName = $attributes[$casUsernameAttribute][0];
 
         if ($casconfig->getValue('attributes', true)) {
-            $attributesToTransfer = $casconfig->getValue('attributes_to_transfer', array());
+            $attributesToTransfer = $casconfig->getValue('attributes_to_transfer', []);
 
             if (sizeof($attributesToTransfer) > 0) {
-                $casAttributes = array();
+                $casAttributes = [];
 
                 foreach ($attributesToTransfer as $key) {
                     if (array_key_exists($key, $attributes)) {
@@ -48,34 +51,34 @@ class sspmod_casserver_Cas_AttributeExtractor
                 $casAttributes = $attributes;
             }
         } else {
-            $casAttributes = array();
+            $casAttributes = [];
         }
 
-        return array(
+        return [
             'user' => $userName,
             'attributes' => $casAttributes
-        );
+        ];
     }
 
     /**
      * Process any authproc filters defined in the configuration. The Authproc filters must only
      * rely on 'Attributes' being available and not on additional SAML state
      * @param array $attributes The current attributes
-     * @param SimpleSAML_Configuration $casconfig The cas configuration
+     * @param \SimpleSAML\Configuration $casconfig The cas configuration
      * @return array The attributes post processing.
      */
-    private function invokeAuthProc(array $attributes, SimpleSAML_Configuration $casconfig)
+    private function invokeAuthProc(array $attributes, Configuration $casconfig)
     {
-        $filters = $casconfig->getArray('authproc', array());
+        $filters = $casconfig->getArray('authproc', []);
 
-        $state = array(
+        $state = [
             'Attributes' => $attributes
-        );
+        ];
         foreach ($filters as $config) {
-            $className = SimpleSAML_Module::resolveClass(
+            $className = Module::resolveClass(
                 $config['class'],
-                'Auth_Process',
-                'SimpleSAML_Auth_ProcessingFilter'
+                'Auth\Process',
+                \SimpleSAML\Auth\ProcessingFilter::class
             );
             $filter = new $className($config, null);
             $filter->process($state);

--- a/lib/Cas/Ticket/SQLTicketStore.php
+++ b/lib/Cas/Ticket/SQLTicketStore.php
@@ -221,12 +221,28 @@ class SQLTicketStore extends TicketStore
                 $query = $this->pdo->prepare($query);
                 $query->execute($data);
                 return;
+            default:
+                /* Default implementation. Try INSERT, and UPDATE if that fails. */
+
+                $insertQuery = 'INSERT INTO '.$table.' '.$colNames.' '.$values;
+                $insertQuery = $this->pdo->prepare($insertQuery);
+
+                $this->insertOrUpdateFallback($table, $keys, $data, $insertQuery);
+                return;
         }
 
-        /* Default implementation. Try INSERT, and UPDATE if that fails. */
+    }
 
-        $insertQuery = 'INSERT INTO '.$table.' '.$colNames.' '.$values;
-        $insertQuery = $this->pdo->prepare($insertQuery);
+
+    /**
+     * @param string $table
+     * @param array $keys
+     * @param array $data
+     * @param \PDOStatement|bool $insertQuery
+     * @return void
+     */
+    private function insertOrUpdateFallback($table, array $keys, array $data, $insertQuery)
+    {
         try {
             $insertQuery->execute($data);
             return;
@@ -255,8 +271,7 @@ class SQLTicketStore extends TicketStore
             }
         }
 
-        $updateQuery = 'UPDATE '.$table.' SET '.implode(',', $updateCols).' WHERE '.
-            implode(' AND ', $condCols);
+        $updateQuery = 'UPDATE '.$table.' SET '.implode(',', $updateCols).' WHERE '.implode(' AND ', $condCols);
         $updateQuery = $this->pdo->prepare($updateQuery);
         $updateQuery->execute($data);
     }

--- a/tests/lib/AttributeExtractorTest.php
+++ b/tests/lib/AttributeExtractorTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Simplesamlphp\Casserver;
+
+class AttributeExtractorTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Confirm behavior of a default configuration
+     */
+    public function testNoCasConfig()
+    {
+        $casConfig = array(// Default is to use eppn and copy all attributes
+        );
+
+        $attributes = array(
+            'eduPersonPrincipalName' => array('testuser@example.com'),
+            'additionalAttribute' => array('Taco Club')
+        );
+        $attributeExtractor = new \sspmod_casserver_Cas_AttributeExtractor();
+        $result = $attributeExtractor->extractUserAndAttributes(
+            $attributes,
+            \SimpleSAML_Configuration::loadFromArray($casConfig)
+        );
+
+        $this->assertEquals('testuser@example.com', $result['user']);
+        $this->assertEquals($attributes, $result['attributes']);
+    }
+
+    /**
+     * Test disable attribute copying
+     */
+    public function testNoAttributeCopying()
+    {
+        $casConfig = array(
+            'attributes' => false
+        );
+
+        $attributes = array(
+            'eduPersonPrincipalName' => array('testuser@example.com'),
+            'additionalAttribute' => array('Taco Club')
+        );
+        $attributeExtractor = new \sspmod_casserver_Cas_AttributeExtractor();
+        $result = $attributeExtractor->extractUserAndAttributes(
+            $attributes,
+            \SimpleSAML_Configuration::loadFromArray($casConfig)
+        );
+
+        $this->assertEquals('testuser@example.com', $result['user']);
+        $this->assertEquals([], $result['attributes']);
+    }
+
+    /**
+     * Confirm customizing the attribute for user and attributes to copy
+     */
+    public function testCustomAttributeCopy()
+    {
+        $casConfig = array(
+            'attrname' => 'userNameAttribute',
+            'attributes_to_transfer' => array(
+                'exampleAttribute',
+                'additionalAttribute'
+            )
+        );
+
+        $attributes = array(
+            'userNameAttribute' => array('testuser@example.com'),
+            'additionalAttribute' => array('Taco Club')
+        );
+        $attributeExtractor = new \sspmod_casserver_Cas_AttributeExtractor();
+        $result = $attributeExtractor->extractUserAndAttributes(
+            $attributes,
+            \SimpleSAML_Configuration::loadFromArray($casConfig)
+        );
+
+        $this->assertEquals('testuser@example.com', $result['user']);
+        $this->assertEquals(array('additionalAttribute' => array('Taco Club')), $result['attributes']);
+    }
+}

--- a/tests/lib/AttributeExtractorTest.php
+++ b/tests/lib/AttributeExtractorTest.php
@@ -76,4 +76,68 @@ class AttributeExtractorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('testuser@example.com', $result['user']);
         $this->assertEquals(array('additionalAttribute' => array('Taco Club')), $result['attributes']);
     }
+
+    /**
+     * Confirm empty authproc has no affect
+     */
+    public function testEmptyAuthproc()
+    {
+        $casConfig = array(// Default is to use eppn and copy all attributes
+        );
+
+        $attributes = array(
+            'eduPersonPrincipalName' => array('testuser@example.com'),
+            'additionalAttribute' => array('Taco Club'),
+            'authproc' => array(),
+        );
+        $attributeExtractor = new \sspmod_casserver_Cas_AttributeExtractor();
+        $result = $attributeExtractor->extractUserAndAttributes(
+            $attributes,
+            \SimpleSAML_Configuration::loadFromArray($casConfig)
+        );
+
+        $this->assertEquals('testuser@example.com', $result['user']);
+        $this->assertEquals($attributes, $result['attributes']);
+    }
+
+    /**
+     * Test authproc configurations can adjust the attributes.
+     */
+    public function testAuthprocConfig()
+    {
+        // Authproc filters need a config.php defined
+        putenv('SIMPLESAMLPHP_CONFIG_DIR=' . dirname(__DIR__) . '/config/');
+        $casConfig = array(// Default is to use eppn and copy all attributes
+            'authproc' => array(
+                array(
+                    'class' => 'core:AttributeMap',
+                    'oid2name',
+                    'urn:example' => 'additionalAttribute'
+                )
+            ),
+            'attributes_to_transfer' => array(
+                'not-affected-by-authproc',
+                'additionalAttribute'
+            )
+        );
+
+        $attributes = array(
+            'urn:oid:1.3.6.1.4.1.5923.1.1.1.6' => array('testuser@example.com'),
+            'urn:example' => array('Taco Club'),
+            'not-affected-by-authproc' => array('Value')
+        );
+        $attributeExtractor = new \sspmod_casserver_Cas_AttributeExtractor();
+        // The authproc filters will remap the attributes prior to mapping them to CAS attributes
+        $result = $attributeExtractor->extractUserAndAttributes(
+            $attributes,
+            \SimpleSAML_Configuration::loadFromArray($casConfig)
+        );
+
+        $expectedAttributes = array(
+            'additionalAttribute' => array('Taco Club'),
+            'not-affected-by-authproc' => array('Value')
+        );
+        $this->assertEquals('testuser@example.com', $result['user']);
+        $this->assertEquals($expectedAttributes, $result['attributes']);
+    }
 }

--- a/tests/lib/AttributeExtractorTest.php
+++ b/tests/lib/AttributeExtractorTest.php
@@ -10,13 +10,14 @@ class AttributeExtractorTest extends \PHPUnit_Framework_TestCase
      */
     public function testNoCasConfig()
     {
-        $casConfig = array(// Default is to use eppn and copy all attributes
-        );
+        $casConfig = [
+            // Default is to use eppn and copy all attributes
+        ];
 
-        $attributes = array(
-            'eduPersonPrincipalName' => array('testuser@example.com'),
-            'additionalAttribute' => array('Taco Club')
-        );
+        $attributes = [
+            'eduPersonPrincipalName' => ['testuser@example.com'],
+            'additionalAttribute' => ['Taco Club']
+        ];
         $attributeExtractor = new \sspmod_casserver_Cas_AttributeExtractor();
         $result = $attributeExtractor->extractUserAndAttributes(
             $attributes,
@@ -32,14 +33,14 @@ class AttributeExtractorTest extends \PHPUnit_Framework_TestCase
      */
     public function testNoAttributeCopying()
     {
-        $casConfig = array(
+        $casConfig = [
             'attributes' => false
-        );
+        ];
 
-        $attributes = array(
-            'eduPersonPrincipalName' => array('testuser@example.com'),
-            'additionalAttribute' => array('Taco Club')
-        );
+        $attributes = [
+            'eduPersonPrincipalName' => ['testuser@example.com'],
+            'additionalAttribute' => ['Taco Club']
+        ];
         $attributeExtractor = new \sspmod_casserver_Cas_AttributeExtractor();
         $result = $attributeExtractor->extractUserAndAttributes(
             $attributes,
@@ -55,18 +56,18 @@ class AttributeExtractorTest extends \PHPUnit_Framework_TestCase
      */
     public function testCustomAttributeCopy()
     {
-        $casConfig = array(
+        $casConfig = [
             'attrname' => 'userNameAttribute',
-            'attributes_to_transfer' => array(
+            'attributes_to_transfer' => [
                 'exampleAttribute',
                 'additionalAttribute'
-            )
-        );
+            ]
+        ];
 
-        $attributes = array(
-            'userNameAttribute' => array('testuser@example.com'),
-            'additionalAttribute' => array('Taco Club')
-        );
+        $attributes = [
+            'userNameAttribute' => ['testuser@example.com'],
+            'additionalAttribute' => ['Taco Club']
+        ];
         $attributeExtractor = new \sspmod_casserver_Cas_AttributeExtractor();
         $result = $attributeExtractor->extractUserAndAttributes(
             $attributes,
@@ -74,7 +75,7 @@ class AttributeExtractorTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals('testuser@example.com', $result['user']);
-        $this->assertEquals(array('additionalAttribute' => array('Taco Club')), $result['attributes']);
+        $this->assertEquals(['additionalAttribute' => ['Taco Club']], $result['attributes']);
     }
 
     /**
@@ -82,14 +83,15 @@ class AttributeExtractorTest extends \PHPUnit_Framework_TestCase
      */
     public function testEmptyAuthproc()
     {
-        $casConfig = array(// Default is to use eppn and copy all attributes
-        );
+        $casConfig = [
+            // Default is to use eppn and copy all attributes
+        ];
 
-        $attributes = array(
-            'eduPersonPrincipalName' => array('testuser@example.com'),
-            'additionalAttribute' => array('Taco Club'),
-            'authproc' => array(),
-        );
+        $attributes = [
+            'eduPersonPrincipalName' => ['testuser@example.com'],
+            'additionalAttribute' => ['Taco Club'],
+            'authproc' => [],
+        ];
         $attributeExtractor = new \sspmod_casserver_Cas_AttributeExtractor();
         $result = $attributeExtractor->extractUserAndAttributes(
             $attributes,
@@ -107,36 +109,37 @@ class AttributeExtractorTest extends \PHPUnit_Framework_TestCase
     {
         // Authproc filters need a config.php defined
         putenv('SIMPLESAMLPHP_CONFIG_DIR=' . dirname(__DIR__) . '/config/');
-        $casConfig = array(// Default is to use eppn and copy all attributes
-            'authproc' => array(
-                array(
+        $casConfig = [
+            // Default is to use eppn and copy all attributes
+            'authproc' => [
+                [
                     'class' => 'core:AttributeMap',
                     'oid2name',
                     'urn:example' => 'additionalAttribute'
-                )
-            ),
-            'attributes_to_transfer' => array(
+                ]
+            ],
+            'attributes_to_transfer' => [
                 'not-affected-by-authproc',
                 'additionalAttribute'
-            )
-        );
+            ]
+        ];
 
-        $attributes = array(
-            'urn:oid:1.3.6.1.4.1.5923.1.1.1.6' => array('testuser@example.com'),
-            'urn:example' => array('Taco Club'),
-            'not-affected-by-authproc' => array('Value')
-        );
+        $attributes = [
+            'urn:oid:1.3.6.1.4.1.5923.1.1.1.6' => ['testuser@example.com'],
+            'urn:example' => ['Taco Club'],
+            'not-affected-by-authproc' => ['Value']
+        ];
         $attributeExtractor = new \sspmod_casserver_Cas_AttributeExtractor();
         // The authproc filters will remap the attributes prior to mapping them to CAS attributes
         $result = $attributeExtractor->extractUserAndAttributes(
             $attributes,
-            \SimpleSAML_Configuration::loadFromArray($casConfig)
+            \SimpleSAML\Configuration::loadFromArray($casConfig)
         );
 
-        $expectedAttributes = array(
-            'additionalAttribute' => array('Taco Club'),
-            'not-affected-by-authproc' => array('Value')
-        );
+        $expectedAttributes = [
+            'additionalAttribute' => ['Taco Club'],
+            'not-affected-by-authproc' => ['Value']
+        ];
         $this->assertEquals('testuser@example.com', $result['user']);
         $this->assertEquals($expectedAttributes, $result['attributes']);
     }

--- a/www/login.php
+++ b/www/login.php
@@ -149,9 +149,9 @@ if (array_key_exists('language', $_GET)) {
 }
 
 if (isset($_GET['service'])) {
-    $attributes = $as->getAttributes();
+    $attributeExtractor = new \sspmod_casserver_Cas_AttributeExtractor();
+    $mappedAttributes = $attributeExtractor->extractUserAndAttributes($as->getAttributes(), $casconfig);
 
-    $casUsernameAttribute = $casconfig->getValue('attrname', 'eduPersonPrincipalName');
 
     $userName = $attributes[$casUsernameAttribute][0];
 
@@ -176,8 +176,8 @@ if (isset($_GET['service'])) {
     $serviceTicket = $ticketFactory->createServiceTicket([
         'service' => $_GET['service'],
         'forceAuthn' => $forceAuthn,
-        'userName' => $userName,
-        'attributes' => $casAttributes,
+        'userName' => $mappedAttributes['user'],
+        'attributes' => $mappedAttributes['attributes'],
         'proxies' => [],
         'sessionId' => $sessionTicket['id']
     ]);


### PR DESCRIPTION
On some occasions we use the casserver module in situations where it is desirable to be able to run authproc filters prior to mapping to cas attributes. For us those situations are:

* Using an authsource that doesn't support authproc filters
* Using an pre-existing authsource that already maps attributes to oid names, and we want to release friendly names for cas attributes
* We want to vary attribute names for specific cas services.

There is a warning in the configuration that only certain authproc filters can be used.

I think this feature is broadly useful enough to include in the main module.