### PR TITLE
Add support for optional method parameter at login

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,13 @@ matrix:
 before_script:
   - export SIMPLESAMLPHP_CONFIG_DIR=`pwd`/tests/config/
   - mkdir tests/ticketcache
-  - git clone https://github.com/simplesamlphp/simplesamlphp testwww
-  - cd testwww && composer require simplesamlphp/simplesamlphp-module-casserver --update-no-dev
-  - cd www && php -S localhost:8732 &
-  - export WEBPID=$! && cd ..
   - composer require "simplesamlphp/simplesamlphp:${SIMPLESAMLPHP_VERSION}" --no-update
   - composer update --no-interaction
+  # Link this branch/pr/etc of simplesamlphp-module-casserver into SSP's vendor directory
+  - php tests/bootstrap.php
+  - php -S localhost:8732 -t `pwd`/vendor/simplesamlphp/simplesamlphp/www &
+  - export WEBPID=$!
+
   - if [[ "$TRAVIS_PHP_VERSION" == "7.3" ]]; then composer require --dev vimeo/psalm; fi
 
 script:
@@ -34,7 +35,7 @@ script:
   - if [[ "$TRAVIS_PHP_VERSION" == "7.3" ]]; then vendor/bin/psalm; fi
 
 after_success:
-  - kill -kill $WEBPID && rm -rf testwww
+  - kill -kill $WEBPID
   # Codecov, need to edit bash uploader for incorrect TRAVIS_PYTHON_VERSION environment variable matching, at least until codecov/codecov-bash#133 is resolved
   - curl -s https://codecov.io/bash > .codecov
   - sed -i -e 's/TRAVIS_.*_VERSION/^TRAVIS_.*_VERSION=/' .codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ before_script:
   - php tests/bootstrap.php
   - php -S localhost:8732 -t `pwd`/vendor/simplesamlphp/simplesamlphp/www &
   - export WEBPID=$!
-
   - if [[ "$TRAVIS_PHP_VERSION" == "7.3" ]]; then composer require --dev vimeo/psalm; fi
 
 script:

--- a/lib/Cas/AttributeExtractor.php
+++ b/lib/Cas/AttributeExtractor.php
@@ -80,6 +80,7 @@ class sspmod_casserver_Cas_AttributeExtractor
                 'Auth\Process',
                 \SimpleSAML\Auth\ProcessingFilter::class
             );
+            /** @psalm-suppress InvalidStringClass */
             $filter = new $className($config, null);
             $filter->process($state);
         }

--- a/tests/lib/AttributeExtractorTest.php
+++ b/tests/lib/AttributeExtractorTest.php
@@ -2,6 +2,8 @@
 
 namespace Simplesamlphp\Casserver;
 
+use SimpleSAML\Configuration;
+
 class AttributeExtractorTest extends \PHPUnit_Framework_TestCase
 {
 
@@ -21,7 +23,7 @@ class AttributeExtractorTest extends \PHPUnit_Framework_TestCase
         $attributeExtractor = new \sspmod_casserver_Cas_AttributeExtractor();
         $result = $attributeExtractor->extractUserAndAttributes(
             $attributes,
-            \SimpleSAML_Configuration::loadFromArray($casConfig)
+            Configuration::loadFromArray($casConfig)
         );
 
         $this->assertEquals('testuser@example.com', $result['user']);
@@ -44,7 +46,7 @@ class AttributeExtractorTest extends \PHPUnit_Framework_TestCase
         $attributeExtractor = new \sspmod_casserver_Cas_AttributeExtractor();
         $result = $attributeExtractor->extractUserAndAttributes(
             $attributes,
-            \SimpleSAML_Configuration::loadFromArray($casConfig)
+            Configuration::loadFromArray($casConfig)
         );
 
         $this->assertEquals('testuser@example.com', $result['user']);
@@ -71,7 +73,7 @@ class AttributeExtractorTest extends \PHPUnit_Framework_TestCase
         $attributeExtractor = new \sspmod_casserver_Cas_AttributeExtractor();
         $result = $attributeExtractor->extractUserAndAttributes(
             $attributes,
-            \SimpleSAML_Configuration::loadFromArray($casConfig)
+            Configuration::loadFromArray($casConfig)
         );
 
         $this->assertEquals('testuser@example.com', $result['user']);
@@ -95,7 +97,7 @@ class AttributeExtractorTest extends \PHPUnit_Framework_TestCase
         $attributeExtractor = new \sspmod_casserver_Cas_AttributeExtractor();
         $result = $attributeExtractor->extractUserAndAttributes(
             $attributes,
-            \SimpleSAML_Configuration::loadFromArray($casConfig)
+            Configuration::loadFromArray($casConfig)
         );
 
         $this->assertEquals('testuser@example.com', $result['user']);
@@ -133,7 +135,7 @@ class AttributeExtractorTest extends \PHPUnit_Framework_TestCase
         // The authproc filters will remap the attributes prior to mapping them to CAS attributes
         $result = $attributeExtractor->extractUserAndAttributes(
             $attributes,
-            \SimpleSAML\Configuration::loadFromArray($casConfig)
+            Configuration::loadFromArray($casConfig)
         );
 
         $expectedAttributes = [

--- a/tests/www/LoginIntegrationTest.php
+++ b/tests/www/LoginIntegrationTest.php
@@ -134,17 +134,17 @@ class LoginIntegrationTest extends \PHPUnit_Framework_TestCase
         $dom = new \DOMDocument;
         $dom->loadHTML($body);
         $form = $dom->getElementsByTagName('form');
-        $this->assertEquals($service_url, $form[0]->getAttribute('action'));
+        $this->assertEquals($service_url, $form->item(0)->getAttribute('action'));
         $formInputs = $dom->getElementsByTagName('input');
         //note: $formInputs[0] is '<input type="submit" style="display:none;" />' . See the post.php template from SSP 
         $this->assertEquals(
             'ticket',
-            $formInputs[1]->getAttribute('name')
+            $formInputs->item(1)->getAttribute('name')
 
         );
         $this->assertStringStartsWith(
             'ST-',
-            $formInputs[1]->getAttribute('value'),
+            $formInputs->item(1)->getAttribute('value'),
             ''
         );
     }

--- a/tests/www/LoginIntegrationTest.php
+++ b/tests/www/LoginIntegrationTest.php
@@ -103,7 +103,49 @@ class LoginIntegrationTest extends \PHPUnit_Framework_TestCase
         $this->assertStringStartsWith(
             $service_url . '?ticket=ST-',
             $response->getHeader('Location')[0],
-            'Link should read the correct socialname from the idpdisco_saml_lastidp cookie'
+            'Ticket should be part of the redirect.'
+        );
+    }
+
+    /**
+     * test a valid service URL with Post
+     */
+    public function testValidServiceUrlWithPost()
+    {
+        $service_url = 'http://host1.domain:1234/path1';
+        $client = new Client();
+        // Use cookies Jar to store auth session cookies
+        $jar = new CookieJar;
+        // Setup authenticated cookies
+        $this->authenticate($jar);
+        $response = $client->get(
+            self::$LINK_URL,
+            [
+                'query' => ['service' => $service_url, 'method' => 'POST'],
+                'cookies' => $jar,
+                'allow_redirects' => false, // Disable redirects since the service url can't be redirected to
+            ]
+        );
+        // POST responds with a form that is uses JavaScript to submit
+        $this->assertEquals(200, $response->getStatusCode());
+
+        // Validate the form contains the required elements
+        $body = $response->getBody()->getContents();
+        $dom = new \DOMDocument;
+        $dom->loadHTML($body);
+        $form = $dom->getElementsByTagName('form');
+        $this->assertEquals($service_url, $form[0]->getAttribute('action'));
+        $formInputs = $dom->getElementsByTagName('input');
+        //note: $formInputs[0] is '<input type="submit" style="display:none;" />' . See the post.php template from SSP 
+        $this->assertEquals(
+            'ticket',
+            $formInputs[1]->getAttribute('name')
+
+        );
+        $this->assertStringStartsWith(
+            'ST-',
+            $formInputs[1]->getAttribute('value'),
+            ''
         );
     }
 

--- a/www/login.php
+++ b/www/login.php
@@ -98,6 +98,10 @@ if (!$as->isAuthenticated() || ($forceAuthn && $sessionRenewId != $requestRenewI
         $query['service'] = $_REQUEST['service'];
     }
 
+    if (isset($_REQUEST['method'])) {
+        $query['method'] = $_REQUEST['method'];
+    }
+
     if (isset($_REQUEST['renew'])) {
         $query['renew'] = $_REQUEST['renew'];
     }

--- a/www/login.php
+++ b/www/login.php
@@ -35,6 +35,8 @@ require_once('utility/urlUtils.php');
 
 $forceAuthn = isset($_GET['renew']) && $_GET['renew'];
 $isPassive = isset($_GET['gateway']) && $_GET['gateway'];
+// Determine if client wants us to post or redirect the response. Default is redirect.
+$redirect = !(isset($_GET['method']) && 'POST' === $_GET['method']);
 
 $casconfig = \SimpleSAML\Configuration::getConfig('module_casserver.php');
 
@@ -170,7 +172,12 @@ if (isset($_GET['service'])) {
 
     $parameters['ticket'] = $serviceTicket['id'];
 
-    \SimpleSAML\Utils\HTTP::redirectTrustedURL(\SimpleSAML\Utils\HTTP::addURLParameters($_GET['service'], $parameters));
+    if ($redirect) {
+        SimpleSAML\Utils\HTTP::redirectTrustedURL(SimpleSAML\Utils\HTTP::addURLParameters($_GET['service'],
+            $parameters));
+    } else {
+        SimpleSAML\Utils\HTTP::submitPOSTData($_GET['service'], $parameters);
+    }
 } else {
     \SimpleSAML\Utils\HTTP::redirectTrustedURL(
         \SimpleSAML\Utils\HTTP::addURLParameters(SimpleSAML\Module::getModuleURL('casserver/loggedIn.php'), $parameters)


### PR DESCRIPTION
See https://apereo.github.io/cas/5.0.x/protocol/CAS-Protocol-Specification.html#211-parameters

> method [OPTIONAL, CAS 3.0] - The method to be used when sending responses. While native HTTP redirects (GET) may be utilized as the default method, applications that require a POST response can use this parameter to indicate the method type. It is up to the CAS server implementation to determine whether or not POST responses are supported.