### PR TITLE
Improve handling of illegal attribute names

### DIFF
--- a/lib/Cas/Protocol/Cas20.php
+++ b/lib/Cas/Protocol/Cas20.php
@@ -136,13 +136,13 @@ class Cas20
                  * can only  contain letters, digits, hyphens, underscores, and periods
                  */
                 $_name = str_replace(':', '_', $name);
-                try {
+                if ($this->isValidXmlName() === true) {
                     foreach ($values as $value) {
                         $casAttributes->appendChild(
                             $this->generateCas20Attribute($xmlDocument, $_name, $value)
                         );
                     }
-                } catch (DOMException $e) {
+                } else {
                     Logger::warning("Dom exception creating attribute '$_name'. Continuing without atrribute'");
                 }
             }
@@ -275,5 +275,20 @@ class Cas20
         $attributeElement->appendChild($attributeValueNode);
 
         return $attributeElement;
+    }
+
+
+    /**
+     * @param string $name
+     * @return bool
+     */
+    private function isValidXmlName($name)
+    {
+        try {
+            new \DOMElement($name);
+            return true;
+        } catch(\DOMException $e) {
+            return false;
+        }
     }
 }

--- a/tests/lib/Cas/Protocol/Cas20Test.php
+++ b/tests/lib/Cas/Protocol/Cas20Test.php
@@ -1,0 +1,56 @@
+<?php
+namespace Simplesamlphp\Casserver;
+
+use SimpleSAML\Module\casserver\Cas\Protocol\Cas20;
+
+class Cas20Test extends \PHPUnit_Framework_TestCase
+{
+
+    public function testAttributeToXmlConversion()
+    {
+
+            $casConfig = \SimpleSAML\Configuration::loadFromArray([
+                'attributes' => true, //send all attributes
+            ]);
+
+
+            $userAttributes = [
+                'lastName' => ['lasty'],
+                'valuesAreEscaped' => [
+                    '>abc<blah>',
+                ],
+                // too many illegal characters
+                'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname' => ['Firsty'],
+                // ':' will get turn to '_'
+                'urn:oid:0.9.2342.19200300.100.1.1' => ['someValue'],
+                'urn:oid:1.3.6.1.4.1.34199.1.7.1.5.2' => [
+                    'CN=Some-Service,OU=Non-Privileged,OU=Groups,DC=exmple,DC=com',
+                    'CN=Other Servics,OU=Non-Privileged,OU=Groups,DC=example,DC=com'
+                ],
+
+            ];
+
+            $casProtocol = new Cas20($casConfig);
+            $casProtocol->setAttributes($userAttributes);
+
+            $xml = $casProtocol->getValidateSuccessResponse('myUser');
+
+            $expectedXml = <<<'EOD'
+<?xml version="1.0"?>
+<cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
+<cas:authenticationSuccess>
+<cas:user>myUser</cas:user>
+<cas:attributes>
+<cas:lastName>lasty</cas:lastName>
+<cas:valuesAreEscaped>&gt;abc&lt;blah&gt;</cas:valuesAreEscaped>
+<cas:urn_oid_0.9.2342.19200300.100.1.1>someValue</cas:urn_oid_0.9.2342.19200300.100.1.1>
+<cas:urn_oid_1.3.6.1.4.1.34199.1.7.1.5.2>CN=Some-Service,OU=Non-Privileged,OU=Groups,DC=exmple,DC=com</cas:urn_oid_1.3.6.1.4.1.34199.1.7.1.5.2>
+<cas:urn_oid_1.3.6.1.4.1.34199.1.7.1.5.2>CN=Other Servics,OU=Non-Privileged,OU=Groups,DC=example,DC=com</cas:urn_oid_1.3.6.1.4.1.34199.1.7.1.5.2>
+</cas:attributes>
+</cas:authenticationSuccess>
+</cas:serviceResponse>
+EOD;
+            //var_dump($xml);
+            $this->assertEquals($expectedXml, $xml);
+    }
+}


### PR DESCRIPTION
Not all attribute names make valid xml elements. Catch and log cases
where an invalid name was generated, rather than erroring on ticket
xml generation.