### PR TITLE
Start Internal Process for Integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,6 @@ before_script:
   - composer update --no-interaction
   # Link this branch/pr/etc of simplesamlphp-module-casserver into SSP's vendor directory
   - php tests/bootstrap.php
-  - php -S localhost:8732 -t `pwd`/vendor/simplesamlphp/simplesamlphp/www &
-  - export WEBPID=$!
   - if [[ "$TRAVIS_PHP_VERSION" == "7.3" ]]; then composer require --dev vimeo/psalm; fi
 
 script:
@@ -33,7 +31,6 @@ script:
   - if [[ "$TRAVIS_PHP_VERSION" == "7.3" ]]; then vendor/bin/psalm; fi
 
 after_success:
-  - kill -kill $WEBPID
   # Codecov, need to edit bash uploader for incorrect TRAVIS_PYTHON_VERSION environment variable matching, at least until codecov/codecov-bash#133 is resolved
   - curl -s https://codecov.io/bash > .codecov
   - sed -i -e 's/TRAVIS_.*_VERSION/^TRAVIS_.*_VERSION=/' .codecov

--- a/composer.json
+++ b/composer.json
@@ -5,15 +5,25 @@
     "homepage": "https://github.com/simplesamlphp/simplesamlphp-module-casserver",
     "license": "LGPL-2.1",
     "type": "simplesamlphp-module",
+    "config": {
+        "preferred-install": {
+            "simplesamlphp/simplesamlphp": "source",
+            "*": "dist"
+        }
+    },
     "require": {
         "php": ">=5.6",
         "simplesamlphp/composer-module-installer": "~1.1",
         "webmozart/assert": "1.4"
     },
+    "autoload-dev": {
+        "psr-4": {
+            "SimpleSAML\\Test\\": "vendor/simplesamlphp/simplesamlphp/tests"
+        }
+    },
     "require-dev": {
-        "guzzlehttp/guzzle": "~6.0",
-        "phpunit/phpunit": "~5.7",
         "simplesamlphp/simplesamlphp": "^1.17",
+        "phpunit/phpunit": "~5.7",
         "satooshi/php-coveralls": "^1.0"
     },
     "support": {

--- a/tests/www/LoginIntegrationTest.php
+++ b/tests/www/LoginIntegrationTest.php
@@ -56,8 +56,8 @@ class LoginIntegrationTest extends \PHPUnit_Framework_TestCase
         $this->server = new BuiltInServer();
         $this->server_addr = $this->server->start();
         $this->server_pid = $this->server->getPid();
-        $this->shared_file = sys_get_temp_dir() . '/' . $this->server_pid . '.lock';
-        $this->cookies_file = sys_get_temp_dir() . '/' . $this->server_pid . '.cookies';
+        $this->shared_file = sys_get_temp_dir().'/'.$this->server_pid.'.lock';
+        $this->cookies_file = sys_get_temp_dir().'/'.$this->server_pid.'.cookies';
     }
 
     /**
@@ -181,7 +181,7 @@ class LoginIntegrationTest extends \PHPUnit_Framework_TestCase
         }
         $this->assertEquals($service_url, $item->getAttribute('action'));
         $formInputs = $dom->getElementsByTagName('input');
-        //note: $formInputs[0] is '<input type="submit" style="display:none;" />' . See the post.php template from SSP
+        //note: $formInputs[0] is '<input type="submit" style="display:none;" />'. See the post.php template from SSP
         $item = $formInputs->item(1);
         if (is_null($item)) {
             $this->fail('Unable to parse response.');

--- a/tests/www/LoginIntegrationTest.php
+++ b/tests/www/LoginIntegrationTest.php
@@ -49,6 +49,7 @@ class LoginIntegrationTest extends \PHPUnit_Framework_TestCase
 
     /**
      * The setup method that is run before any tests in this class.
+     * @return void
      */
     protected function setup()
     {
@@ -62,6 +63,7 @@ class LoginIntegrationTest extends \PHPUnit_Framework_TestCase
     /**
      * The tear down method that is executed after all tests in this class.
      * Removes the lock file and cookies file
+     * @return void
      */
     protected function tearDown()
     {
@@ -77,6 +79,7 @@ class LoginIntegrationTest extends \PHPUnit_Framework_TestCase
      */
     public function testNoQueryParameters()
     {
+        /** @var array $resp */
         $resp = $this->server->get(self::$LINK_URL, [],
             [
                 CURLOPT_COOKIEJAR => $this->cookies_file,
@@ -99,6 +102,7 @@ class LoginIntegrationTest extends \PHPUnit_Framework_TestCase
      */
     public function testWrongServiceUrl()
     {
+        /** @var array $resp */
         $resp = $this->server->get(self::$LINK_URL,
             ['service' => 'http://not-legal'],
             [
@@ -126,6 +130,7 @@ class LoginIntegrationTest extends \PHPUnit_Framework_TestCase
 
         $this->authenticate();
 
+        /** @var array $resp */
         $resp = $this->server->get(self::$LINK_URL,
             ['service' => $service_url],
             [
@@ -150,6 +155,7 @@ class LoginIntegrationTest extends \PHPUnit_Framework_TestCase
         $service_url = 'http://host1.domain:1234/path1';
 
         $this->authenticate();
+        /** @var array $resp */
         $resp = $this->server->get(self::$LINK_URL,
             [
                 'service' => $service_url,
@@ -201,6 +207,7 @@ class LoginIntegrationTest extends \PHPUnit_Framework_TestCase
     private function authenticate()
     {
         // Use cookies Jar to store auth session cookies
+        /** @var array $resp */
         $resp = $this->server->get(
             self::$LINK_URL, [],
             [


### PR DESCRIPTION
I'm always frustrated when you need to do an additional setup to get your unit tests working for a project. The Integration tests should not require a manual intervention.
By starting an internal process which listens to the port, we can just start the test run. Without a manual step.
You can also write a wrapper around the script, but I think this makes things just more complicated.
