### PR TITLE
Add "debugMode" to cas service to print ticket xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,26 @@ Install with composer
 
 See the `config-templates` folder for examples of configuring this module
 
+## Debug
+
+To aid in debugging you can print out the CAS ticket xml rather then returning a ticket id.
+Enable `debugMode` in `module_casserver.php` and then add a query parameter `debugMode=true` to the CAS login url.
+
+Logging in to https://cas.example.com/cas/login?debugMode=true&service=http://localhost/ would now print the xml for that service.
+
+```xml
+<?xml version="1.0">
+<cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
+ <cas:authenticationSuccess>
+  <cas:user>testuser@example.com</cas:user>
+  <cas:attributes>
+   <cas:eduPersonPrincipalName>testuser@example.com</cas:eduPersonPrincipalName>
+   <cas:base64Attributes>false</cas:base64Attributes>
+  </cas:attributes>
+ </cas:authenticationSuccess>
+</cas:serviceResponse>
+```
+
 # Development
 
 Run `phpcs` to check code style

--- a/config-templates/module_casserver.php
+++ b/config-templates/module_casserver.php
@@ -82,4 +82,6 @@ $config = [
     'service_ticket_expire_time' => 5, //how many seconds service tickets are valid for, defaults to 5
     'proxy_granting_ticket_expire_time' => 600, //how many seconds proxy granting tickets are valid for at most, defaults to 3600
     'proxy_ticket_expire_time' => 5, //how many seconds proxy tickets are valid for, defaults to 5
+
+    'debugMode' => true, // If query param debugMode=true is sent to the login endpoint then print cas ticket xml. Default false
 ];

--- a/docs/ChangeLog
+++ b/docs/ChangeLog
@@ -24,7 +24,7 @@ Unreleased
     * Support method parameter at login
     * Improve handling of invalid xml element names for attributes
     * Minimum supported simplesamlphp version bumped to 1.17
-
+    * debugMode option to display cas ticket xml
 
 2018-07-20 Bjorn Rohde Jensen
     * Release 6.1.0

--- a/tests/config/module_casserver.php
+++ b/tests/config/module_casserver.php
@@ -51,7 +51,7 @@ $config = [
     'attributes' => true, // enable transfer of attributes, defaults to false
     'attributes_to_transfer' => ['eduPersonPrincipalName'], // set of attributes to transfer, defaults to all
 
-    'base64attributes' => true, //base64 encode transferred attributes, defaults to false
+    'base64attributes' => false, //base64 encode transferred attributes, defaults to false
     'base64_attributes_indicator_attribute' => 'base64Attributes', /*add an attribute with the value of the base64attributes
                                                                      configuration parameter to the set of transferred attributes.
                                                                      Defaults to not adding an indicator attribute. */
@@ -64,4 +64,6 @@ $config = [
     'service_ticket_expire_time' => 5, //how many seconds service tickets are valid for, defaults to 5
     'proxy_granting_ticket_expire_time' => 600, //how many seconds proxy granting tickets are valid for at most, defaults to 3600
     'proxy_ticket_expire_time' => 5, //how many seconds proxy tickets are valid for, defaults to 5
+
+    'debugMode' => true,
 ];

--- a/tests/www/LoginIntegrationTest.php
+++ b/tests/www/LoginIntegrationTest.php
@@ -152,6 +152,31 @@ class LoginIntegrationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test outputting user info instead of redirecting
+     */
+    public function testDebugOutput()
+    {
+        $service_url = 'http://host1.domain:1234/path1';
+        $this->authenticate();
+        /** @var array $resp */
+        $resp = $this->server->get(
+            self::$LINK_URL,
+            ['service' => $service_url, 'debugMode' => 'true'],
+            [
+                CURLOPT_COOKIEJAR => $this->cookies_file,
+                CURLOPT_COOKIEFILE => $this->cookies_file
+            ]
+        );
+        $this->assertEquals(200, $resp['code']);
+
+        $this->assertContains(
+            '&lt;cas:eduPersonPrincipalName&gt;testuser@example.com&lt;/cas:eduPersonPrincipalName&gt;',
+            $resp['body'],
+            'Attributes should have been printed.'
+        );
+    }
+
+    /**
      * test a valid service URL with Post
      * @return void
      */

--- a/www/login.php
+++ b/www/login.php
@@ -183,7 +183,17 @@ if (isset($_GET['service'])) {
 
     $parameters['ticket'] = $serviceTicket['id'];
 
-    if ($redirect) {
+    if (isset($_GET['debugMode']) && $_GET['debugMode'] == 'true' && $casconfig->getBoolean('debugMode', false)) {
+        $method = 'serviceValidate';
+        // Fake some options for validateTicket
+        $_GET['ticket'] = $serviceTicket['id'];
+        // We want to capture the output from echo used in validateTicket
+        ob_start();
+        require_once 'utility/validateTicket.php';
+        $casResponse = ob_get_contents();
+        ob_end_clean();
+        echo '<pre>' . htmlspecialchars($casResponse) . '</pre>';
+    } elseif ($redirect) {
         HTTP::redirectTrustedURL(HTTP::addURLParameters($_GET['service'], $parameters));
     } else {
         HTTP::submitPOSTData($_GET['service'], $parameters);


### PR DESCRIPTION
Add "debugMode" to cas service to print ticket xml.  This helps people configuring CAS services to see what attributes they are getting, and to debug integration issues.