### PR TITLE
IS-19: Allow service to override cas config

### DIFF
--- a/config-templates/module_casserver.php
+++ b/config-templates/module_casserver.php
@@ -23,14 +23,19 @@ $config = [
          //Any service url string matching any of the following prefixes is accepted
         'http://host1.domain:1234/path1',
         'https://host2.domain:5678/path2/path3',
+        // So is regex
+        '|^https://.*\.domain.com/|',
+        // Some configuration options can be overridden
+        'https://override.example.com' => [
+            'attrname' => 'uid',
+            'attributes_to_transfer' => ['cn'],
+        ],
     ],
 
     'legal_target_service_urls' => [
-         //Any target service url string matching any of the following prefixes is accepted
+        //Any target service url string matching any of the following prefixes is accepted
         'http://host3.domain:4321/path4',
         'https://host4.domain:8765/path5/path6',
-        // So is regex
-        '|^https://.*\.domain.com/|'
     ],
 
     'ticketstore' => [

--- a/docs/ChangeLog
+++ b/docs/ChangeLog
@@ -25,6 +25,7 @@ Unreleased
     * Improve handling of invalid xml element names for attributes
     * Minimum supported simplesamlphp version bumped to 1.17
     * debugMode option to display cas ticket xml
+    * Allow per service overriding of configuration options for www/login
 
 2018-07-20 Bjorn Rohde Jensen
     * Release 6.1.0

--- a/lib/Cas/ServiceValidator.php
+++ b/lib/Cas/ServiceValidator.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace SimpleSAML\Module\casserver\Cas;
+
+use SimpleSAML\Configuration;
+use SimpleSAML\Logger;
+
+/**
+ * Validates if a CAS service can use server
+ * @package SimpleSAML\Module\casserver\Cas
+ */
+class ServiceValidator
+{
+    /**
+     * @var Configuration
+     */
+    private $mainConfig;
+
+    /**
+     * ServiceValidator constructor.
+     * @param Configuration $mainConfig
+     */
+    public function __construct(Configuration $mainConfig)
+    {
+        $this->mainConfig = $mainConfig;
+    }
+
+    /**
+     * Check that the $service is allowed, and if so return the configuration to use.
+     * @param string $service The service url. Assume to already be url decoded
+     * @return Configuration|null Return the configuration to use for this service, or null if service is not allowed
+     */
+    public function checkServiceURL($service)
+    {
+        $isValidService = false;
+        $legalUrl = 'undefined';
+        $configOverride = null;
+        foreach ($this->mainConfig->getArray('legal_service_urls', []) as $index => $value) {
+            // Support two styles:  0 => 'https://example' and 'https://example' => [ extra config ]
+            if (is_int($index)) {
+                $legalUrl = $value;
+                $configOverride = null;
+            } else {
+                $legalUrl = $index;
+                $configOverride = $value;
+            }
+            if (empty($legalUrl)) {
+                Logger::warning("Ignoring empty CAS legal service url '$legalUrl'.");
+                continue;
+            }
+            if (!ctype_alnum($legalUrl[0])) {
+                // Probably a regex. Suppress errors incase the format is invalid
+                $result = @preg_match($legalUrl, $service);
+                if ($result === 1) {
+                    $isValidService = true;
+                    break;
+                } elseif ($result === false) {
+                    Logger::warning("Invalid CAS legal service url '$legalUrl'. Error ".preg_last_error());
+                }
+            } elseif (strpos($service, $legalUrl) === 0) {
+                $isValidService = true;
+                break;
+            }
+        }
+        if ($isValidService) {
+            $serviceConfig = $this->mainConfig->toArray();
+            // Return contextual information about which url rule triggered the validation
+            $serviceConfig['casService'] = [
+                'matchingUrl' => $legalUrl,
+                'serviceUrl'  => $service,
+            ];
+            if ($configOverride) {
+                $serviceConfig = array_merge($serviceConfig, $configOverride);
+            }
+            return Configuration::loadFromArray($serviceConfig);
+        }
+        return null;
+    }
+}

--- a/tests/config/module_casserver.php
+++ b/tests/config/module_casserver.php
@@ -24,6 +24,10 @@ $config = [
         // Any service url string matching any of the following prefixes is accepted
         'http://host1.domain:1234/path1',
         'https://host2.domain:5678/path2/path3',
+        '|https://override.example.com/|' => [
+            'attrname' => 'uid',
+            'attributes_to_transfer' => ['cn'],
+        ]
     ],
 
     'legal_target_service_urls' => [

--- a/tests/lib/ServiceValidatorTest.php
+++ b/tests/lib/ServiceValidatorTest.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: patrick
+ * Date: 4/8/19
+ * Time: 2:58 PM
+ */
+
+namespace Simplesamlphp\Casserver;
+
+use SimpleSAML\Configuration;
+use SimpleSAML\Module\casserver\Cas\ServiceValidator;
+
+class ServiceValidatorTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Test being able to override CAS configuration options per service.
+     *
+     * @param string $service The service url to test
+     * @param array $expectedConfig The expected CAS configuration to use
+     * @dataProvider overridingDataProvider
+     */
+    public function testOverridingServiceConfig($service, $expectedConfig)
+    {
+        $casConfig = [
+            'attrname' => 'defaultAttribute',
+            'service_ticket_expire_time' => 10,
+            'authproc' => [
+                [
+                    'class' => 'core:AttributeMap',
+                    'oid2name',
+                    'urn:example' => 'example'
+                ],
+            ],
+            'legal_service_urls' => [
+                'https://myservice.com',
+                'http://override.config.com/' => [
+                    'attrname' => 'alternateAttribute',
+                ],
+                // Regex match
+                '|^https://.*\.subdomain.com/|',
+                '@^https://override.more.com/avd@' => [
+                    'service_ticket_expire_time' => 5,
+                    'authproc' => [
+                        [
+                            'class' => 'core:AttributeMap',
+                            'oid2custom',
+                            'urn:example' => 'example'
+                        ],
+                    ],
+                ],
+            ]
+        ];
+
+        $serviceValidator = new ServiceValidator(Configuration::loadFromArray($casConfig));
+        $config = $serviceValidator->checkServiceURL($service)->toArray();
+        unset($config['legal_service_urls']);
+        $this->assertEquals($expectedConfig, $config);
+    }
+
+    public function overridingDataProvider()
+    {
+        // The expected configuration if no overrides occur
+        $defaultConfig = [
+            'attrname' => 'defaultAttribute',
+            'service_ticket_expire_time' => 10,
+            'authproc' => [
+                [
+                    'class' => 'core:AttributeMap',
+                    'oid2name',
+                    'urn:example' => 'example'
+                ],
+            ]
+        ];
+        return [
+            [
+                'https://myservice.com/abcd',
+                [
+                    'casService' => [
+                        'matchingUrl' => 'https://myservice.com',
+                        'serviceUrl' => 'https://myservice.com/abcd'
+                    ]
+                ] + $defaultConfig
+            ],
+            [
+                'https://default.subdomain.com/abcd',
+                [
+                    'casService' => [
+                        'matchingUrl' => '|^https://.*\.subdomain.com/|',
+                        'serviceUrl' => 'https://default.subdomain.com/abcd'
+                    ]
+                ] + $defaultConfig
+            ],
+            [
+                'http://override.config.com/xyz',
+                [
+                    'attrname' => 'alternateAttribute',
+                    'casService' => [
+                        'matchingUrl' => 'http://override.config.com/',
+                        'serviceUrl' => 'http://override.config.com/xyz'
+                    ]
+                ] + $defaultConfig
+            ],
+            [
+                'https://override.more.com/avd/qrx',
+                [
+                    'service_ticket_expire_time' => 5,
+                    'authproc' => [
+                        [
+                            'class' => 'core:AttributeMap',
+                            'oid2custom',
+                            'urn:example' => 'example'
+                        ],
+                    ],
+                    'casService' => [
+                        'matchingUrl' => '@^https://override.more.com/avd@',
+                        'serviceUrl' => 'https://override.more.com/avd/qrx'
+                    ]
+                ] + $defaultConfig
+            ],
+        ];
+    }
+
+    /**
+     * Test confirming service url matching and per service configuration
+     * @param string $service the service url to check
+     * @param bool $allowed is the service url allowed?
+     * @return void
+     * @dataProvider checkServiceURLProvider
+     */
+    public function testCheckServiceURL($service, $allowed)
+    {
+        $casConfig = [
+            'legal_service_urls' => [
+                // Regular prefix match
+                'https://myservice.com',
+                'https://anotherservice.com/',
+                'https://anotherservice.com:8080/',
+                'http://sub.domain.com/path/a/b/c',
+                'https://query.param/secure?apple=red',
+                'https://encode.com/space test/',
+
+                // Regex match
+                '|^https://.*\.subdomain.com/|',
+                '#^https://.*-someprefix.com/#',
+                // Invalid settings don't blow up
+                '|invalid-regex',
+                '',
+            ]
+        ];
+        $serviceValidator = new ServiceValidator(Configuration::loadFromArray($casConfig));
+        $config = $serviceValidator->checkServiceURL(urldecode($service));
+        $this->assertEquals($allowed, $config != null, "$service validated wrong");
+    }
+
+
+    /**
+     * @return array
+     */
+    public function checkServiceURLProvider()
+    {
+        return [
+            ['no-match', false],
+            ['https://myservice.com', true],
+            // maybe we should warn if there is no at least a path component of /
+            ['https://myservice.com.at.somedomain', true],
+            ['https://anotherservice.com.nope', false],
+            ['https://anotherservice.com/anypathOk', true],
+            ['https://anotherservice.com:8080/anypathOk', true],
+            ['https://anotherservice.com:8080/', true],
+            ['https://anotherservice.com:9999/', false],
+
+            ['http://sub.domain.com/path/a/b/c/more?query=a', true],
+            // Matching less path fails
+            ['http://sub.domain.com/path/a/b/less', false],
+
+            ['https://query.param/secure?apple=red&b=g', true],
+            // Future improvement: ignore query parameter order
+            //['https://query.param/secure?b=g&apple=red', true],
+            ['https://query.param/secure?b=g', false],
+
+            ['https://encode.com/space test/', true],
+            ['https://encode.com/space+test/', true],
+            ['https://encode.com/space%20test/', true],
+
+            ['https://any.subdomain.com/', true],
+            ['https://two.any.subdomain.com/', true],
+            ['https://path.subdomain.com/abc', true],
+            ['https://subdomain.com/abc', false],
+
+            ['https://anything-someprefix.com/abc', true],
+            ['http://need_an_s-someprefix.com/abc', false],
+
+            ['', false],
+        ];
+    }
+}

--- a/tests/www/LoginIntegrationTest.php
+++ b/tests/www/LoginIntegrationTest.php
@@ -177,6 +177,35 @@ class LoginIntegrationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test outputting user info instead of redirecting
+     */
+    public function testAlternateServiceConfigUsed()
+    {
+        $service_url = 'https://override.example.com/somepath';
+        $this->authenticate();
+        /** @var array $resp */
+        $resp = $this->server->get(
+            self::$LINK_URL,
+            ['service' => $service_url, 'debugMode' => 'true'],
+            [
+                CURLOPT_COOKIEJAR => $this->cookies_file,
+                CURLOPT_COOKIEFILE => $this->cookies_file
+            ]
+        );
+        $this->assertEquals(200, $resp['code']);
+        $this->assertContains(
+            '&lt;cas:user&gt;testuser&lt;/cas:user&gt;',
+            $resp['body'],
+            'cas:user attribute should have been overridden'
+        );
+        $this->assertContains(
+            '&lt;cas:cn&gt;Test User&lt;/cas:cn&gt;',
+            $resp['body'],
+            'Attributes should have been printed with alternate attribute release'
+        );
+    }
+
+    /**
      * test a valid service URL with Post
      * @return void
      */

--- a/www/utility/urlUtils.php
+++ b/www/utility/urlUtils.php
@@ -21,32 +21,22 @@
  *
  */
 
+use SimpleSAML\Configuration;
+use SimpleSAML\Module\casserver\Cas\ServiceValidator;
+
 /**
+ * @deprecated
+ * @see ServiceValidator
  * @param string $service
  * @param array $legal_service_urls
  * @return bool
  */
 function checkServiceURL($service, array $legal_service_urls)
 {
-    foreach ($legal_service_urls as $legalUrl) {
-        if (empty($legalUrl)) {
-            \SimpleSAML\Logger::warning("Ignoring empty CAS legal service url '$legalUrl'.");
-            continue;
-        }
-        if (!ctype_alnum($legalUrl[0])) {
-            // Probably a regex. Suppress errors incase the format is invalid
-            $result = @preg_match($legalUrl, $service);
-            if ($result === 1) {
-                return true;
-            } elseif ($result === false) {
-                \SimpleSAML\Logger::warning("Invalid CAS legal service url '$legalUrl'. Error ".preg_last_error());
-            }
-        } elseif (strpos($service, $legalUrl) === 0) {
-            return true;
-        }
-    }
-
-    return false;
+    //delegate to ServiceValidator until all references to this can be cleaned up
+    $config = Configuration::loadFromArray(['legal_service_urls' => $legal_service_urls]);
+    $serviceValidator = new ServiceValidator($config);
+    return $serviceValidator->checkServiceURL($service) !== null;
 }
 
 

--- a/www/utility/validateTicket.php
+++ b/www/utility/validateTicket.php
@@ -27,6 +27,10 @@
  *
  */
 
+use SimpleSAML\Module\casserver\Cas\Protocol\Cas20;
+use SimpleSAML\Module\casserver\Cas\Ticket\TicketFactory;
+use SimpleSAML\Module\casserver\Cas\Ticket\TicketStore;
+
 require_once('urlUtils.php');
 
 /* Load simpleSAMLphp, configuration and metadata */
@@ -34,6 +38,7 @@ $casconfig = \SimpleSAML\Configuration::getConfig('module_casserver.php');
 
 /* Instantiate protocol handler */
 $protocolClass = \SimpleSAML\Module::resolveClass('casserver:Cas20', 'Cas_Protocol');
+/** @var Cas20 $protocol */
 /** @psalm-suppress InvalidStringClass */
 $protocol = new $protocolClass($casconfig);
 
@@ -43,10 +48,12 @@ if (array_key_exists('service', $_GET) && array_key_exists('ticket', $_GET)) {
     try {
         $ticketStoreConfig = $casconfig->getValue('ticketstore', ['class' => 'casserver:FileSystemTicketStore']);
         $ticketStoreClass = \SimpleSAML\Module::resolveClass($ticketStoreConfig['class'], 'Cas_Ticket');
+        /** @var TicketStore $ticketStore */
         /** @psalm-suppress InvalidStringClass */
         $ticketStore = new $ticketStoreClass($casconfig);
 
         $ticketFactoryClass = SimpleSAML\Module::resolveClass('casserver:TicketFactory', 'Cas_Ticket');
+        /** @var TicketFactory $ticketFactory */
         /** @psalm-suppress InvalidStringClass */
         $ticketFactory = new $ticketFactoryClass($casconfig);
 


### PR DESCRIPTION
Allow each service to override the cas configuration to use in the module. From #19 
Currently working for `www/login.php`.

Other endpoints have no test coverage and are less likely to need this feature, so it seems too risky to incorporate this change into proxy mode.