### PR TITLE
Support alternate service and ticket param names

### DIFF
--- a/tests/config/module_casserver.php
+++ b/tests/config/module_casserver.php
@@ -27,6 +27,9 @@ $config = [
         '|https://override.example.com/|' => [
             'attrname' => 'uid',
             'attributes_to_transfer' => ['cn'],
+        ],
+        'http://changeTicketParam' => [
+            'ticketName' => 'myTicket',
         ]
     ],
 


### PR DESCRIPTION
For some reason (unknown to me) the Apereo java CAS client supports
configuring different query param names for 'service' and 'ticket'.
The combinations we have encountered in the wild for these are
TARGET and SAMLart. It is a requirement in Banner to use these
alernative names for "security".