### PR TITLE
Errors throwing exceptions in login.php should log at ERROR level

### DIFF
--- a/www/login.php
+++ b/www/login.php
@@ -60,7 +60,7 @@ if (isset($serviceUrl)) {
     } else {
         $message = 'Service parameter provided to CAS server is not listed as a legal service: [service] = ' .
             var_export($serviceUrl, true);
-        Logger::debug('casserver:' . $message);
+        Logger::error('casserver:' . $message);
 
         throw new \Exception($message);
     }
@@ -77,7 +77,7 @@ if (array_key_exists('scope', $_GET) && is_string($_GET['scope'])) {
     } else {
         $message = 'Scope parameter provided to CAS server is not listed as legal scope: [scope] = ' .
             var_export($_GET['scope'], true);
-        Logger::debug('casserver:' . $message);
+        Logger::error('casserver:' . $message);
 
         throw new \Exception($message);
     }


### PR DESCRIPTION
There are two places in www/login.php which throw exceptions, which end up in the logs as something like:

> Feb 04 03:00:22 simplesamlphp ERROR [035043badf] SimpleSAML\Error\Error: UNHANDLEDEXCEPTION
> Feb 04 03:00:22 simplesamlphp ERROR [035043badf] Error report with id 0108d5b9 generated.

Which is unhelpful, as the related error messages which are logged immediately preceding the raising of the exception are discarded in a default installation. This patch just changes the log level to "error" in those two cases.
