### PR TITLE
Fix Random utility import to use SimpleSAML\Utils\Random

### DIFF
--- a/src/Cas/Factories/TicketFactory.php
+++ b/src/Cas/Factories/TicketFactory.php
@@ -26,7 +26,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Module\casserver\Cas\Factories;
 
 use SimpleSAML\Configuration;
-use SimpleSAML\XML\Utils\Random;
+use SimpleSAML\Utils\Random;
 
 class TicketFactory
 {

--- a/src/Cas/Factories/TicketFactory.php
+++ b/src/Cas/Factories/TicketFactory.php
@@ -61,7 +61,7 @@ class TicketFactory
         return [
             'id' => $sessionId,
             'validBefore' => $expiresAt,
-            'renewId' => (string) IDValue::generateID(),
+            'renewId' => IDValue::generateID()->getValue(),
         ];
     }
 
@@ -72,7 +72,7 @@ class TicketFactory
      */
     public function createServiceTicket(array $content): array
     {
-        $id = str_replace('_', 'ST-', (string) IDValue::generateID());
+        $id = IDValue::generateID('ST-')->getValue();
         $expiresAt = time() + $this->serviceTicketExpireTime;
 
         return array_merge(['id' => $id, 'validBefore' => $expiresAt], $content);
@@ -85,8 +85,8 @@ class TicketFactory
      */
     public function createProxyGrantingTicket(array $content): array
     {
-        $id = str_replace('_', 'PGT-', (string) IDValue::generateID());
-        $iou = str_replace('_', 'PGTIOU-', (string) IDValue::generateID());
+        $id = IDValue::generateID('PGT-')->getValue();
+        $iou = IDValue::generateID('PGTIOU-')->getValue();
 
         $expireAt = time() + $this->proxyGrantingTicketExpireTime;
 
@@ -100,7 +100,7 @@ class TicketFactory
      */
     public function createProxyTicket(array $content): array
     {
-        $id = str_replace('_', 'PT-', (string) IDValue::generateID());
+        $id = IDValue::generateID('PT-')->getValue();
         $expiresAt = time() + $this->proxyTicketExpireTime;
 
         return array_merge(['id' => $id, 'validBefore' => $expiresAt], $content);

--- a/src/Cas/Factories/TicketFactory.php
+++ b/src/Cas/Factories/TicketFactory.php
@@ -26,7 +26,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Module\casserver\Cas\Factories;
 
 use SimpleSAML\Configuration;
-use SimpleSAML\Utils\Random;
+use SimpleSAML\XMLSchema\Type\IDValue;
 
 class TicketFactory
 {
@@ -58,11 +58,10 @@ class TicketFactory
      */
     public function createSessionTicket(string $sessionId, int $expiresAt): array
     {
-        $randomUtils = new Random();
         return [
             'id' => $sessionId,
             'validBefore' => $expiresAt,
-            'renewId' => $randomUtils->generateID(),
+            'renewId' => (string) IDValue::generateID(),
         ];
     }
 
@@ -73,8 +72,7 @@ class TicketFactory
      */
     public function createServiceTicket(array $content): array
     {
-        $randomUtils = new Random();
-        $id = str_replace('_', 'ST-', $randomUtils->generateID());
+        $id = str_replace('_', 'ST-', (string) IDValue::generateID());
         $expiresAt = time() + $this->serviceTicketExpireTime;
 
         return array_merge(['id' => $id, 'validBefore' => $expiresAt], $content);
@@ -87,9 +85,8 @@ class TicketFactory
      */
     public function createProxyGrantingTicket(array $content): array
     {
-        $randomUtils = new Random();
-        $id = str_replace('_', 'PGT-', $randomUtils->generateID());
-        $iou = str_replace('_', 'PGTIOU-', $randomUtils->generateID());
+        $id = str_replace('_', 'PGT-', (string) IDValue::generateID());
+        $iou = str_replace('_', 'PGTIOU-', (string) IDValue::generateID());
 
         $expireAt = time() + $this->proxyGrantingTicketExpireTime;
 
@@ -103,8 +100,7 @@ class TicketFactory
      */
     public function createProxyTicket(array $content): array
     {
-        $randomUtils = new Random();
-        $id = str_replace('_', 'PT-', $randomUtils->generateID());
+        $id = str_replace('_', 'PT-', (string) IDValue::generateID());
         $expiresAt = time() + $this->proxyTicketExpireTime;
 
         return array_merge(['id' => $id, 'validBefore' => $expiresAt], $content);

--- a/src/Shib13/AuthnResponse.php
+++ b/src/Shib13/AuthnResponse.php
@@ -15,10 +15,10 @@ use SimpleSAML\Configuration;
 use SimpleSAML\Error;
 use SimpleSAML\Metadata\MetaDataStorageHandler;
 use SimpleSAML\Utils;
-use SimpleSAML\Utils\Random;
 use SimpleSAML\XML\DOMDocumentFactory;
 use SimpleSAML\XML\Utils as XMLUtils;
 use SimpleSAML\XML\Validator;
+use SimpleSAML\XMLSchema\Type\IDValue;
 use SimpleXMLElement;
 
 /**
@@ -362,17 +362,16 @@ class AuthnResponse
             $scopedAttributes = [];
         }
 
-        $randomUtils = new Random();
         $timeUtils = new Utils\Time();
 
-        $id = $randomUtils->generateID();
+        $id = (string) IDValue::generateID();
         $issueInstant = $timeUtils->generateTimestamp();
 
         // 30 seconds timeskew back in time to allow differing clocks
         $notBefore = $timeUtils->generateTimestamp(time() - 30);
 
         $assertionExpire = $timeUtils->generateTimestamp(time() + 300); // 5 minutes
-        $assertionid = $randomUtils->generateID();
+        $assertionid = (string) IDValue::generateID();
 
         $spEntityId = $sp->getString('entityid');
 
@@ -380,7 +379,7 @@ class AuthnResponse
         $base64 = $sp->getOptionalBoolean('base64attributes', false);
 
         $namequalifier = $sp->getOptionalString('NameQualifier', $spEntityId);
-        $nameid = $randomUtils->generateID();
+        $nameid = (string)IDValue::generateID();
         $subjectNode =
             '<Subject>' .
             '<NameIdentifier' .

--- a/src/Shib13/AuthnResponse.php
+++ b/src/Shib13/AuthnResponse.php
@@ -15,9 +15,9 @@ use SimpleSAML\Configuration;
 use SimpleSAML\Error;
 use SimpleSAML\Metadata\MetaDataStorageHandler;
 use SimpleSAML\Utils;
+use SimpleSAML\Utils\Random;
 use SimpleSAML\XML\DOMDocumentFactory;
 use SimpleSAML\XML\Utils as XMLUtils;
-use SimpleSAML\XML\Utils\Random;
 use SimpleSAML\XML\Validator;
 use SimpleXMLElement;
 

--- a/src/Shib13/AuthnResponse.php
+++ b/src/Shib13/AuthnResponse.php
@@ -364,14 +364,14 @@ class AuthnResponse
 
         $timeUtils = new Utils\Time();
 
-        $id = (string) IDValue::generateID();
+        $id = IDValue::generateID()->getValue();
         $issueInstant = $timeUtils->generateTimestamp();
 
         // 30 seconds timeskew back in time to allow differing clocks
         $notBefore = $timeUtils->generateTimestamp(time() - 30);
 
         $assertionExpire = $timeUtils->generateTimestamp(time() + 300); // 5 minutes
-        $assertionid = (string) IDValue::generateID();
+        $assertionid = IDValue::generateID()->getValue();
 
         $spEntityId = $sp->getString('entityid');
 

--- a/tests/src/TicketValidatorTest.php
+++ b/tests/src/TicketValidatorTest.php
@@ -12,7 +12,7 @@ use SimpleSAML\Module\casserver\Cas\CasException;
 use SimpleSAML\Module\casserver\Cas\Ticket\FileSystemTicketStore;
 use SimpleSAML\Module\casserver\Cas\Ticket\TicketStore;
 use SimpleSAML\Module\casserver\Cas\TicketValidator;
-use SimpleSAML\XML\Utils\Random;
+use SimpleSAML\Utils\Random;
 
 class TicketValidatorTest extends TestCase
 {

--- a/tests/src/TicketValidatorTest.php
+++ b/tests/src/TicketValidatorTest.php
@@ -12,7 +12,7 @@ use SimpleSAML\Module\casserver\Cas\CasException;
 use SimpleSAML\Module\casserver\Cas\Ticket\FileSystemTicketStore;
 use SimpleSAML\Module\casserver\Cas\Ticket\TicketStore;
 use SimpleSAML\Module\casserver\Cas\TicketValidator;
-use SimpleSAML\Utils\Random;
+use SimpleSAML\XMLSchema\Type\IDValue;
 
 class TicketValidatorTest extends TestCase
 {
@@ -170,8 +170,7 @@ class TicketValidatorTest extends TestCase
      */
     private function createTicket(string $serviceUrl, int $expiration = 0): array
     {
-        $randomUtils = new Random();
-        $id = $randomUtils->generateID();
+        $id = (string) IDValue::generateID();
         $serviceTicket = [
             'id' => $id,
             'validBefore' => time() + $expiration,

--- a/tests/src/TicketValidatorTest.php
+++ b/tests/src/TicketValidatorTest.php
@@ -170,7 +170,7 @@ class TicketValidatorTest extends TestCase
      */
     private function createTicket(string $serviceUrl, int $expiration = 0): array
     {
-        $id = (string) IDValue::generateID();
+        $id = IDValue::generateID()->getValue();
         $serviceTicket = [
             'id' => $id,
             'validBefore' => time() + $expiration,


### PR DESCRIPTION
This PR updates `Random` imports from `SimpleSAML\XML\Utils\Random` to `SimpleSAML\Utils\Random`. The XML-namespaced `Random` helper was removed from `simplesamlphp/xml-common` in **2.8.x**, so the old import now breaks (or triggers warnings) when projects upgrade. This is a compatibility fix only—ID generation behavior remains unchanged, but the code now works with newer `xml-common`/SimpleSAMLphp dependency sets.